### PR TITLE
Add option to silent prints

### DIFF
--- a/video_indexer/main.py
+++ b/video_indexer/main.py
@@ -18,8 +18,9 @@ class VideoIndexer():
         self.vi_account_id = vi_account_id
         self.access_token = None
 
-    def get_access_token(self):
-        print('Getting video indexer access token...')
+    def get_access_token(self, silent=False):
+        if not silent:
+            print('Getting video indexer access token...')
         headers = {
             'Ocp-Apim-Subscription-Key': self.vi_subscription_key
         }
@@ -37,21 +38,24 @@ class VideoIndexer():
         )
 
         access_token = access_token_req.text[1:-1]
-        print('Access Token: {}'.format(access_token))
+        if not silent:
+            print('Access Token: {}'.format(access_token))
         self.access_token = access_token
         return access_token
 
-    def check_access_token(self):
+    def check_access_token(self, silent=False):
         if not self.access_token:
-            self.get_access_token()
+            self.get_access_token(silent)
 
     def upload_to_video_indexer(
         self, input_filename, video_name='',
-        video_language='English', streaming_preset='Default', indexing_preset='Default'
+        video_language='English', streaming_preset='Default', indexing_preset='Default',
+        silent=False
     ):
-        self.check_access_token()
+        self.check_access_token(silent)
 
-        print('Uploading video to video indexer...')
+        if not silent:
+            print('Uploading video to video indexer...')
         params = {
             'streamingPreset': streaming_preset,
             'indexingPreset': indexing_preset,
@@ -83,26 +87,29 @@ class VideoIndexer():
 
             if upload_video_req.status_code == 429:  # hit throttling limit, sleep and retry
                 error_resp = upload_video_req.json()
-                print('Throttling limit hit. Error message: {}'.format(error_resp.get('message')))
+                if not silent:
+                    print('Throttling limit hit. Error message: {}'.format(error_resp.get('message')))
                 retry_after = get_retry_after_from_message(error_resp.get('message'))
                 time.sleep(retry_after + 1)
                 retry_count -= 1
                 continue
 
-            print('Error uploading video to video indexer: {}'.format(upload_video_req.json()))
+            if not silent:
+                print('Error uploading video to video indexer: {}'.format(upload_video_req.json()))
             raise Exception('Error uploading video to video indexer')
 
         response = upload_video_req.json()
         return response['id']
 
-    def get_video_info(self, video_id, video_language='English'):
-        self.check_access_token()
+    def get_video_info(self, video_id, video_language='English', silent=False):
+        self.check_access_token(silent)
 
         params = {
             'accessToken': self.access_token,
             'language': video_language
         }
-        print('Getting video info for: {}'.format(video_id))
+        if not silent:
+            print('Getting video info for: {}'.format(video_id))
 
         get_video_info_req = requests.get(
             'https://api.videoindexer.ai/{loc}/Accounts/{acc_id}/Videos/{video_id}/Index'.format(
@@ -114,17 +121,18 @@ class VideoIndexer():
         )
         response = get_video_info_req.json()
 
-        if response['state'] == 'Processing':
+        if response['state'] == 'Processing' and not silent:
             print('Video still processing, current status: {}'.format(
                 response['videos'][0]['processingProgress'],
             ))
 
         return response
 
-    def get_caption_from_video_indexer(self, video_id, caption_format='vtt', video_language='English'):
-        self.check_access_token()
+    def get_caption_from_video_indexer(self, video_id, caption_format='vtt', video_language='English', silent=False):
+        self.check_access_token(silent)
 
-        print('Getting caption from video: {}'.format(video_id))
+        if not silent:
+            print('Getting caption from video: {}'.format(video_id))
         params = {
             'accessToken': self.access_token,
             'format': caption_format,
@@ -142,8 +150,9 @@ class VideoIndexer():
 
         return caption_req.content
 
-    def get_thumbnail_from_video_indexer(self, video_id, thumbnail_id):
-        print('Getting thumbnail from video: {}, thumbnail: {}'.format(video_id, thumbnail_id))
+    def get_thumbnail_from_video_indexer(self, video_id, thumbnail_id, silent=False):
+        if not silent:
+            print('Getting thumbnail from video: {}, thumbnail: {}'.format(video_id, thumbnail_id))
         params = {
             'accessToken': self.access_token
         }


### PR DESCRIPTION
Hi, first of all - a great utility library, it's been a great time saver.
I'd like to suggest a small change that would allow the user to silent all prints as I found it a tad annoying to have the library spam my standard output with numerous messages, especially when polling for processing results.

I wondered whether some kind of a "global" silencing (passing a `silent` option once, in the `VideoIndexer` constructor), or a more seamless solution (such as overwriting `sys.stdout`) would be better, but in the end, I settled for the simplest solution, which is the ability to pass a `silent` arg to each method capable of printing something.